### PR TITLE
Fix: 헤더 반응형 / 토글메뉴 로직 수정 및 컴포넌트 분리

### DIFF
--- a/public/data/header/toggle.json
+++ b/public/data/header/toggle.json
@@ -1,0 +1,28 @@
+{
+  "toggle": [
+    {
+      "name": "내 벨로그",
+      "path": "/id"
+    },
+    {
+      "name": "새 글 작성",
+      "path": "/write"
+    },
+    {
+      "name": "임시 글",
+      "path": "/saves"
+    },
+    {
+      "name": "읽기 목록",
+      "path": "/lists/liked"
+    },
+    {
+      "name": "설정",
+      "path": "/setting"
+    },
+    {
+      "name": "로그아웃",
+      "path": "/"
+    }
+  ]
+}

--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -1,20 +1,17 @@
 import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
 import {
-  darkModeBackgroundColor,
-  darkModeFontColor,
   lightModeBackgroundColor,
   lightModeFontColor,
-  darkModeNewPostBtnColor,
   lightModeNewPostBtnColor,
-  darkModeToggle,
   lightModeToggle,
-  darkModeToggleBackgound,
   lightModeToggleBackgound,
-  darkModeATagHoverText,
   lightModeATagHoverText,
-  darkModeATagHoverBackground,
   lightModeATagHoverBackground,
+  backgroundPage,
+  text1,
+  backgroundElement1,
+  primary1,
 } from './styles/color';
 
 const GlobalStyle = createGlobalStyle`
@@ -27,26 +24,26 @@ const GlobalStyle = createGlobalStyle`
 
   body {
     margin-top: 4rem;
-    background: ${props => (props.isDarkMode ? darkModeBackgroundColor : lightModeBackgroundColor)};
-    color: ${props => (props.isDarkMode ? darkModeFontColor : lightModeFontColor)};
+    background: ${props => (props.isDarkMode ? backgroundPage : lightModeBackgroundColor)};
+    color: ${props => (props.isDarkMode ? text1 : lightModeFontColor)};
   }
 
   :root {
-    --text: ${props => (props.isDarkMode ? darkModeFontColor : lightModeFontColor)};
-    --new-post-btn-background: ${props => (props.isDarkMode ? darkModeNewPostBtnColor : lightModeNewPostBtnColor)};
-    --new-post-btn-hover-text: ${props => (props.isDarkMode ? lightModeFontColor : darkModeFontColor)};
-    --new-post-btn-hover-background: ${props => (props.isDarkMode ? lightModeNewPostBtnColor : darkModeNewPostBtnColor)};
-    --toggle-hover: ${props => (props.isDarkMode ? darkModeToggle : lightModeToggle)};
-    --toggle-background: ${props => (props.isDarkMode ? darkModeToggleBackgound : lightModeToggleBackgound)};
-    --a-tag-hover-text: ${props => (props.isDarkMode ? darkModeATagHoverText : lightModeATagHoverText)};
-    --a-tag-hover-background: ${props => (props.isDarkMode ? darkModeATagHoverBackground : lightModeATagHoverBackground)};
+    --text: ${props => (props.isDarkMode ? text1 : lightModeFontColor)};
+    --new-post-btn-background: ${props => (props.isDarkMode ? backgroundElement1 : lightModeNewPostBtnColor)};
+    --new-post-btn-hover-text: ${props => (props.isDarkMode ? lightModeFontColor : text1)};
+    --new-post-btn-hover-background: ${props => (props.isDarkMode ? lightModeNewPostBtnColor : backgroundElement1)};
+    --toggle-hover: ${props => (props.isDarkMode ? text1 : lightModeToggle)};
+    --toggle-background: ${props => (props.isDarkMode ? backgroundElement1 : lightModeToggleBackgound)};
+    --a-tag-hover-text: ${props => (props.isDarkMode ? primary1 : lightModeATagHoverText)};
+    --a-tag-hover-background: ${props => (props.isDarkMode ? backgroundElement1 : lightModeATagHoverBackground)};
   }
 
   a {
     text-decoration: none;
 
     :visited {
-      color: ${props => (props.isDarkMode ? darkModeFontColor : lightModeFontColor)};
+      color: ${props => (props.isDarkMode ? text1 : lightModeFontColor)};
   }
   }
 

--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -26,9 +26,9 @@ const GlobalStyle = createGlobalStyle`
   }
 
   body {
+    margin-top: 4rem;
     background: ${props => (props.isDarkMode ? darkModeBackgroundColor : lightModeBackgroundColor)};
     color: ${props => (props.isDarkMode ? darkModeFontColor : lightModeFontColor)};
-    max-width: 1728px;
   }
 
   :root {

--- a/src/components/PostList/Post/PostInfo/index.jsx
+++ b/src/components/PostList/Post/PostInfo/index.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { darkModeFontColor, darkModeTextColor } from '../../../../styles/color';
+import { text1 } from '../../../../styles/color';
 
 const PostInfo = () => {
   return (
@@ -29,7 +29,7 @@ const PostInfoBox = styled.div`
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    color: ${darkModeFontColor};
+    color: ${text1};
   }
 
   .main-text {
@@ -43,13 +43,13 @@ const PostInfoBox = styled.div`
     line-height: 1.5;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: ${darkModeTextColor};
+    color: #d9d9d9;
   }
 
   .sub-info {
     font-size: 0.75rem;
     line-height: 1.5;
-    color: ${darkModeTextColor};
+    color: #d9d9d9;
   }
 `;
 

--- a/src/components/PostList/Post/UserInfo/index.jsx
+++ b/src/components/PostList/Post/UserInfo/index.jsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { darkModeFontColor, darkModeTextColor } from '../../../../styles/color';
 import { AiFillHeart } from 'react-icons/ai';
+import { text1 } from '../../../../styles/color';
 
 const UserInfo = () => {
   return (
@@ -41,10 +41,10 @@ const UserInfoBox = styled.div`
     }
 
     .user-by {
-      color: ${darkModeTextColor};
+      color: #d9d9d9;
 
       .user-name {
-        color: ${darkModeFontColor};
+        color: ${text1};
         font-weight: bold;
       }
     }

--- a/src/components/PostList/index.jsx
+++ b/src/components/PostList/index.jsx
@@ -1,7 +1,7 @@
 import Post from './Post';
 import PostListNavBar from '../PostListNavBar';
 import styled from 'styled-components';
-import { postListMaxWidth1056px, postListMaxWidth1440px, postListMaxWidth1920px } from '../../styles/media';
+import { maxWidth1056px, maxWidth1440px, maxWidth1920px, minWidth250px } from '../../styles/media';
 
 const PostList = () => {
   const arr = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
@@ -32,9 +32,10 @@ const PostListContainer = styled.div`
     }
   }
 
-  ${postListMaxWidth1920px}
-  ${postListMaxWidth1440px}
-  ${postListMaxWidth1056px}
+  ${maxWidth1920px}
+  ${maxWidth1440px}
+  ${maxWidth1056px}
+  ${minWidth250px}
 `;
 
 export default PostList;

--- a/src/components/PostListNavBar/index.jsx
+++ b/src/components/PostListNavBar/index.jsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { darkModeFontColor, darkModeTextColor } from '../../styles/color';
 import { MdOutlineArrowDropDown } from 'react-icons/md';
 import { SlGraph } from 'react-icons/sl';
 import { AiOutlineClockCircle } from 'react-icons/ai';
@@ -59,7 +58,7 @@ const PostListNavBarBox = styled.div`
         height: 3rem;
         margin: 0;
         font-size: 1.125rem;
-        color: ${darkModeTextColor};
+        color: #d9d9d9;
 
         .icon {
           font-size: 1.4rem;
@@ -68,7 +67,7 @@ const PostListNavBarBox = styled.div`
       }
 
       .active {
-        color: ${darkModeFontColor};
+        color: var(--text);
       }
     }
 

--- a/src/layout/Header/ThemeMode/index.jsx
+++ b/src/layout/Header/ThemeMode/index.jsx
@@ -1,0 +1,43 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { darkMode, lightMode } from '../../../store/modules/header';
+import { HiMoon } from 'react-icons/hi';
+import { BsFillSunFill } from 'react-icons/bs';
+import styled from 'styled-components';
+
+const ThemeMode = () => {
+  const isDarkMode = useSelector(state => state.darkMode.isDarkMode);
+  const dispatch = useDispatch();
+
+  const changeTheme = e => {
+    e.target.className = 'theme-mode-change setting-hover';
+    isDarkMode ? dispatch(lightMode()) : dispatch(darkMode());
+  };
+
+  return (
+    <ThemeModeContainer onClick={changeTheme}>
+      <div className='setting-hover'>{isDarkMode ? <HiMoon /> : <BsFillSunFill />}</div>
+    </ThemeModeContainer>
+  );
+};
+
+const ThemeModeContainer = styled.div`
+  @keyframes themeChange {
+    from {
+      width: 10px;
+      height: 10px;
+      transform: rotate(180deg);
+    }
+    to {
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  .theme-mode-change {
+    svg {
+      animation: themeChange 0.1s linear;
+    }
+  }
+`;
+
+export default ThemeMode;

--- a/src/layout/Header/ToggleMenuList/index.jsx
+++ b/src/layout/Header/ToggleMenuList/index.jsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const ToggleMenuList = ({ toggleMenuRef, toggleMenuList, setIsToggleOpen }) => {
+  return (
+    <ToggleMenuListContainer ref={toggleMenuRef}>
+      {toggleMenuList.map(menu => {
+        return (
+          <Link key={menu.name} className='link-tag' to={menu.path} onClick={() => setIsToggleOpen(false)}>
+            {menu.name}
+          </Link>
+        );
+      })}
+    </ToggleMenuListContainer>
+  );
+};
+
+export default ToggleMenuList;
+
+const ToggleMenuListContainer = styled.div`
+  width: 12rem;
+  margin-top: 0.3rem;
+  margin-left: auto;
+  background-color: var(--toggle-background);
+  box-shadow: rgb(0 0 0 / 10%) 0px 0px 8px;
+
+  .link-tag {
+    display: block;
+    padding: 1.25rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+
+    :nth-child(2) {
+      @media only screen and (min-width: 1024px) {
+        display: none;
+      }
+    }
+
+    :hover {
+      color: var(--a-tag-hover-text);
+      background-color: var(--a-tag-hover-background);
+    }
+  }
+`;

--- a/src/layout/Header/ToggleMenuList/index.jsx
+++ b/src/layout/Header/ToggleMenuList/index.jsx
@@ -1,16 +1,34 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import axios from 'axios';
 import styled from 'styled-components';
 
-const ToggleMenuList = ({ toggleMenuRef, toggleMenuList, setIsToggleOpen }) => {
+const ToggleMenuList = ({ toggleMenuRef, setIsToggleOpen }) => {
+  const [toggleMenuList, setToggleMenuList] = useState();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const {
+          data: { toggle },
+        } = await axios.get('data/header/toggle.json');
+        setToggleMenuList(toggle);
+      } catch (error) {
+        console.log('error => ', error);
+      }
+    })();
+  }, []);
+
   return (
     <ToggleMenuListContainer ref={toggleMenuRef}>
-      {toggleMenuList.map(menu => {
-        return (
-          <Link key={menu.name} className='link-tag' to={menu.path} onClick={() => setIsToggleOpen(false)}>
-            {menu.name}
-          </Link>
-        );
-      })}
+      {toggleMenuList &&
+        toggleMenuList.map(menu => {
+          return (
+            <Link key={menu.name} className='link-tag' to={menu.path} onClick={() => setIsToggleOpen(false)}>
+              {menu.name}
+            </Link>
+          );
+        })}
     </ToggleMenuListContainer>
   );
 };

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -43,15 +43,17 @@ const Header = () => {
   return (
     <Positioner>
       <Content>
-        <Logo to='/'>velog</Logo>
+        <Link className='logo' to='/'>
+          velog
+        </Link>
         <RightIcons>
           <ThemeMode />
           <Link className='search setting-hover' to='/search'>
             <BiSearch />
           </Link>
-          <div className='new-post'>
-            <Link to='/write'>새 글 작성</Link>
-          </div>
+          <Link className='new-post' to='/write'>
+            새 글 작성
+          </Link>
           <div className='my-zone' ref={myZoneRef} onClick={() => setIsToggleOpen(!isToggleOpen)}>
             <CgProfile className='profile' />
             <VscTriangleDown className='toggle' />
@@ -91,16 +93,16 @@ const Content = styled.div`
   justify-content: space-between;
   width: 100%;
   height: 4rem;
-`;
 
-const Logo = styled(Link)`
-  display: flex;
-  align-items: center;
-  font-size: 1.5rem;
-  letter-spacing: 0.2rem;
+  .logo {
+    display: flex;
+    align-items: center;
+    font-size: 1.5rem;
+    letter-spacing: 0.2rem;
 
-  @media only screen and (max-width: 1023px) {
-    font-size: 1.25rem;
+    @media only screen and (max-width: 1023px) {
+      font-size: 1.25rem;
+    }
   }
 `;
 
@@ -130,20 +132,18 @@ const RightIcons = styled.div`
   }
 
   .new-post {
-    a {
-      padding: 0.4rem 1rem;
-      margin-left: 0.5rem;
-      border: 1px solid var(--text);
-      border-radius: 1.3rem;
-      background-color: var(--new-post-btn-background);
-      font-size: 1rem;
-      font-weight: bold;
+    padding: 0.4rem 1rem;
+    margin-left: 0.5rem;
+    border: 1px solid var(--text);
+    border-radius: 1.3rem;
+    background-color: var(--new-post-btn-background);
+    font-size: 1rem;
+    font-weight: bold;
 
-      :hover {
-        background-color: var(--new-post-btn-hover-background);
-        color: var(--new-post-btn-hover-text);
-        transition: all 0.125s ease-in 0s;
-      }
+    :hover {
+      background-color: var(--new-post-btn-hover-background);
+      color: var(--new-post-btn-hover-text);
+      transition: all 0.125s ease-in 0s;
     }
 
     @media only screen and (max-width: 1023px) {

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { toggle } from '../../styles/color';
+import { backgroundElement9 } from '../../styles/color';
 import { BiSearch } from 'react-icons/bi';
 import { CgProfile } from 'react-icons/cg';
 import { VscTriangleDown } from 'react-icons/vsc';
@@ -154,7 +154,7 @@ const RightIcons = styled.div`
       cursor: pointer;
 
       width: 12px;
-      color: ${toggle};
+      color: ${backgroundElement9};
 
       :hover {
         color: var(--toggle-hover);

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -1,19 +1,17 @@
 import { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
 import { toggle } from '../../styles/color';
 import { BiSearch } from 'react-icons/bi';
 import { CgProfile } from 'react-icons/cg';
 import { VscTriangleDown } from 'react-icons/vsc';
 import styled from 'styled-components';
-import ToggleMenuList from './ToggleMenuList';
 import ThemeMode from './ThemeMode';
+import ToggleMenuList from './ToggleMenuList';
 
 const Header = () => {
   const myZoneRef = useRef();
   const toggleMenuRef = useRef();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
-  const [toggleMenuList, setToggleMenuList] = useState();
 
   useEffect(() => {
     const closeToggleMenu = e => {
@@ -26,19 +24,6 @@ const Header = () => {
       document.removeEventListener('mousedown', closeToggleMenu);
     };
   }, [isToggleOpen]);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const {
-          data: { toggle },
-        } = await axios.get('data/header/toggle.json');
-        setToggleMenuList(toggle);
-      } catch (error) {
-        console.log('error => ', error);
-      }
-    })();
-  }, []);
 
   return (
     <Positioner>
@@ -60,7 +45,7 @@ const Header = () => {
           </div>
         </RightIcons>
       </Content>
-      {isToggleOpen && toggleMenuList && <ToggleMenuList toggleMenuRef={toggleMenuRef} toggleMenuList={toggleMenuList} setIsToggleOpen={setIsToggleOpen} />}
+      {isToggleOpen && <ToggleMenuList toggleMenuRef={toggleMenuRef} setIsToggleOpen={setIsToggleOpen} />}
     </Positioner>
   );
 };

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -21,16 +21,15 @@ const Header = () => {
     isDarkMode ? dispatch(lightMode()) : dispatch(darkMode());
   };
 
-  const closeToggleMenu = e => {
-    if (isToggleOpen && toggleMenuRef !== e.target) setIsToggleOpen(false);
-  };
-
   useEffect(() => {
-    document.addEventListener('click', closeToggleMenu);
-    return () => {
-      document.removeEventListener('click', closeToggleMenu);
+    const closeToggleMenu = e => {
+      if (isToggleOpen && toggleMenuRef !== e.target) setIsToggleOpen(false);
     };
-  }, []);
+    document.addEventListener('mousedown', closeToggleMenu);
+    return () => {
+      document.removeEventListener('mousedown', closeToggleMenu);
+    };
+  }, [isToggleOpen]);
 
   return (
     <Positioner>

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import axios from 'axios';
 import { darkMode, lightMode } from '../../store/modules/header';
 import MediaQuery from 'react-responsive';
 import { toggle } from '../../styles/color';
@@ -10,13 +11,12 @@ import { BsFillSunFill } from 'react-icons/bs';
 import { CgProfile } from 'react-icons/cg';
 import { VscTriangleDown } from 'react-icons/vsc';
 import styled from 'styled-components';
-import axios from 'axios';
 
 const Header = () => {
   const toggleMenuRef = useRef();
   const myZoneRef = useRef();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
-  const [toggleMenuList, setToggleMenuList] = useState([]);
+  const [toggleMenuList, setToggleMenuList] = useState();
   const isDarkMode = useSelector(state => state.darkMode.isDarkMode);
   const dispatch = useDispatch();
 
@@ -61,11 +61,9 @@ const Header = () => {
           <Link className='search setting-hover' to='/search'>
             <BiSearch />
           </Link>
-          <MediaQuery minWidth={1024}>
-            <div className='new-post'>
-              <Link to='/write'>새 글 작성</Link>
-            </div>
-          </MediaQuery>
+          <div className='new-post'>
+            <Link to='/write'>새 글 작성</Link>
+          </div>
           <div className='my-zone' ref={myZoneRef} onClick={() => setIsToggleOpen(!isToggleOpen)}>
             <CgProfile className='profile' />
             <VscTriangleDown className='toggle' />
@@ -185,7 +183,12 @@ const RightIcons = styled.div`
         transition: all 0.125s ease-in 0s;
       }
     }
+
+    @media only screen and (max-width: 1023px) {
+      display: none;
+    }
   }
+
   .my-zone {
     display: flex;
     align-items: center;
@@ -225,6 +228,13 @@ const ToggleMenu = styled.div`
     padding: 1.25rem;
     font-size: 0.9rem;
     cursor: pointer;
+
+    :nth-child(2) {
+      @media only screen and (min-width: 1024px) {
+        display: none;
+      }
+    }
+
     :hover {
       color: var(--a-tag-hover-text);
       background-color: var(--a-tag-hover-background);

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -1,28 +1,19 @@
 import { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
 import axios from 'axios';
-import { darkMode, lightMode } from '../../store/modules/header';
 import { toggle } from '../../styles/color';
-import { HiMoon } from 'react-icons/hi';
 import { BiSearch } from 'react-icons/bi';
-import { BsFillSunFill } from 'react-icons/bs';
 import { CgProfile } from 'react-icons/cg';
 import { VscTriangleDown } from 'react-icons/vsc';
 import styled from 'styled-components';
+import ToggleMenuList from './ToggleMenuList';
+import ThemeMode from './ThemeMode';
 
 const Header = () => {
-  const toggleMenuRef = useRef();
   const myZoneRef = useRef();
+  const toggleMenuRef = useRef();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
   const [toggleMenuList, setToggleMenuList] = useState();
-  const isDarkMode = useSelector(state => state.darkMode.isDarkMode);
-  const dispatch = useDispatch();
-
-  const changeTheme = e => {
-    e.target.className = 'theme-mode-change setting-hover';
-    isDarkMode ? dispatch(lightMode()) : dispatch(darkMode());
-  };
 
   useEffect(() => {
     const closeToggleMenu = e => {
@@ -54,9 +45,7 @@ const Header = () => {
       <Content>
         <Logo to='/'>velog</Logo>
         <RightIcons>
-          <div className='theme-mode setting-hover' onClick={changeTheme}>
-            {isDarkMode ? <HiMoon /> : <BsFillSunFill />}
-          </div>
+          <ThemeMode />
           <Link className='search setting-hover' to='/search'>
             <BiSearch />
           </Link>
@@ -69,17 +58,7 @@ const Header = () => {
           </div>
         </RightIcons>
       </Content>
-      {isToggleOpen && toggleMenuList && (
-        <ToggleMenu ref={toggleMenuRef}>
-          {toggleMenuList.map(menu => {
-            return (
-              <Link key={menu.name} className='link-tag' to={menu.path} onClick={() => setIsToggleOpen(false)}>
-                {menu.name}
-              </Link>
-            );
-          })}
-        </ToggleMenu>
-      )}
+      {isToggleOpen && toggleMenuList && <ToggleMenuList toggleMenuRef={toggleMenuRef} toggleMenuList={toggleMenuList} setIsToggleOpen={setIsToggleOpen} />}
     </Positioner>
   );
 };
@@ -150,24 +129,6 @@ const RightIcons = styled.div`
     }
   }
 
-  @keyframes themeChange {
-    from {
-      width: 10px;
-      height: 10px;
-      transform: rotate(180deg);
-    }
-    to {
-      width: 24px;
-      height: 24px;
-    }
-  }
-
-  .theme-mode-change {
-    svg {
-      animation: themeChange 0.1s linear;
-    }
-  }
-
   .new-post {
     a {
       padding: 0.4rem 1rem;
@@ -213,32 +174,6 @@ const RightIcons = styled.div`
       :hover {
         color: var(--toggle-hover);
       }
-    }
-  }
-`;
-
-const ToggleMenu = styled.div`
-  width: 12rem;
-  margin-top: 0.3rem;
-  margin-left: auto;
-  background-color: var(--toggle-background);
-  box-shadow: rgb(0 0 0 / 10%) 0px 0px 8px;
-
-  .link-tag {
-    display: block;
-    padding: 1.25rem;
-    font-size: 0.9rem;
-    cursor: pointer;
-
-    :nth-child(2) {
-      @media only screen and (min-width: 1024px) {
-        display: none;
-      }
-    }
-
-    :hover {
-      color: var(--a-tag-hover-text);
-      background-color: var(--a-tag-hover-background);
     }
   }
 `;

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -1,13 +1,14 @@
 import { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
-import { backgroundElement9 } from '../../styles/color';
 import { BiSearch } from 'react-icons/bi';
 import { CgProfile } from 'react-icons/cg';
 import { VscTriangleDown } from 'react-icons/vsc';
-import styled from 'styled-components';
 import ThemeMode from './ThemeMode';
 import ToggleMenuList from './ToggleMenuList';
+import styled from 'styled-components';
+import { backgroundElement9 } from '../../styles/color';
+import { maxWidth1056px, maxWidth1440px, maxWidth1920px, minWidth250px } from '../../styles/media';
 
 const Header = () => {
   const myZoneRef = useRef();
@@ -75,17 +76,12 @@ const Positioner = styled.div`
   transform: translate(-50%, 0%);
   z-index: 1;
   padding: 0 1rem;
-  width: 1024px;
-  max-width: 1728px;
-  min-width: 250px;
+  width: 1728px;
 
-  @media only screen and (max-width: 1023px) {
-    width: 100%;
-  }
-
-  @media only screen and (min-width: 1440px) {
-    width: 1376px;
-  }
+  ${maxWidth1920px}
+  ${maxWidth1440px}
+  ${maxWidth1056px}
+  ${minWidth250px}
 `;
 
 const Content = styled.div`

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { darkMode, lightMode } from '../../store/modules/header';
 import MediaQuery from 'react-responsive';
@@ -9,10 +9,13 @@ import { BiSearch } from 'react-icons/bi';
 import { BsFillSunFill } from 'react-icons/bs';
 import { CgProfile } from 'react-icons/cg';
 import { VscTriangleDown } from 'react-icons/vsc';
+import styled from 'styled-components';
+import axios from 'axios';
 
 const Header = () => {
   const toggleMenuRef = useRef();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
+  const [toggleMenuList, setToggleMenuList] = useState([]);
   const isDarkMode = useSelector(state => state.darkMode.isDarkMode);
   const dispatch = useDispatch();
 
@@ -21,30 +24,45 @@ const Header = () => {
     isDarkMode ? dispatch(lightMode()) : dispatch(darkMode());
   };
 
+  // useEffect(() => {
+  //   const closeToggleMenu = e => {
+  //     if (isToggleOpen && toggleMenuRef !== e.target) {
+  //       setIsToggleOpen(false);
+  //     }
+  //   };
+  //   document.addEventListener('mousedown', closeToggleMenu);
+  //   return () => {
+  //     document.removeEventListener('mousedown', closeToggleMenu);
+  //   };
+  // }, [isToggleOpen]);
+
   useEffect(() => {
-    const closeToggleMenu = e => {
-      if (isToggleOpen && toggleMenuRef !== e.target) setIsToggleOpen(false);
-    };
-    document.addEventListener('mousedown', closeToggleMenu);
-    return () => {
-      document.removeEventListener('mousedown', closeToggleMenu);
-    };
-  }, [isToggleOpen]);
+    (async () => {
+      try {
+        const {
+          data: { toggle },
+        } = await axios.get('data/header/toggle.json');
+        setToggleMenuList(toggle);
+      } catch (error) {
+        console.log('error => ', error);
+      }
+    })();
+  }, []);
 
   return (
     <Positioner>
       <Content>
-        <Logo href='/'>velog</Logo>
+        <Logo to='/'>velog</Logo>
         <RightIcons>
           <div className='theme-mode setting-hover' onClick={changeTheme}>
             {isDarkMode ? <HiMoon /> : <BsFillSunFill />}
           </div>
-          <a className='search setting-hover' href='/search'>
+          <Link className='search setting-hover' to='/search'>
             <BiSearch />
-          </a>
+          </Link>
           <MediaQuery minWidth={1024}>
             <div className='new-post'>
-              <a href='/'>새 글 작성</a>
+              <Link to='/write'>새 글 작성</Link>
             </div>
           </MediaQuery>
           <div className='profile' onClick={() => setIsToggleOpen(!isToggleOpen)}>
@@ -55,15 +73,15 @@ const Header = () => {
           </div>
         </RightIcons>
       </Content>
-      {isToggleOpen && (
+      {isToggleOpen && toggleMenuList && (
         <ToggleMenu ref={toggleMenuRef}>
-          <a href='/'>내 벨로그</a>
-          <MediaQuery maxWidth={1023}>
-            <a>새 글 작성</a>
-          </MediaQuery>
-          <a href='/'>임시 글</a>
-          <a href='/'>읽기 목록</a>
-          <a href='/'>로그아웃</a>
+          {toggleMenuList.map(menu => {
+            return (
+              <Link key={menu.name} className='link-tag' to={menu.path}>
+                {menu.name}
+              </Link>
+            );
+          })}
         </ToggleMenu>
       )}
     </Positioner>
@@ -98,7 +116,7 @@ const Content = styled.div`
   height: 4rem;
 `;
 
-const Logo = styled.a`
+const Logo = styled(Link)`
   display: flex;
   align-items: center;
   font-size: 1.5rem;
@@ -208,7 +226,7 @@ const ToggleMenu = styled.div`
   background-color: var(--toggle-background);
   box-shadow: rgb(0 0 0 / 10%) 0px 0px 8px;
 
-  a {
+  .link-tag {
     display: block;
     padding: 1.25rem;
     font-size: 0.9rem;

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import axios from 'axios';
 import { darkMode, lightMode } from '../../store/modules/header';
-import MediaQuery from 'react-responsive';
 import { toggle } from '../../styles/color';
 import { HiMoon } from 'react-icons/hi';
 import { BiSearch } from 'react-icons/bi';
@@ -85,8 +84,6 @@ const Header = () => {
   );
 };
 
-export default Header;
-
 const Positioner = styled.div`
   display: flex;
   flex-direction: column;
@@ -103,6 +100,10 @@ const Positioner = styled.div`
 
   @media only screen and (max-width: 1023px) {
     width: 100%;
+  }
+
+  @media only screen and (min-width: 1440px) {
+    width: 1376px;
   }
 `;
 
@@ -241,3 +242,5 @@ const ToggleMenu = styled.div`
     }
   }
 `;
+
+export default Header;

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -65,11 +65,9 @@ const Header = () => {
               <Link to='/write'>새 글 작성</Link>
             </div>
           </MediaQuery>
-          <div className='profile' onClick={() => setIsToggleOpen(!isToggleOpen)}>
-            <CgProfile />
-          </div>
-          <div className='toggle' onClick={() => setIsToggleOpen(!isToggleOpen)}>
-            <VscTriangleDown />
+          <div className='my-zone' onClick={() => setIsToggleOpen(!isToggleOpen)}>
+            <CgProfile className='profile' />
+            <VscTriangleDown className='toggle' />
           </div>
         </RightIcons>
       </Content>
@@ -187,32 +185,27 @@ const RightIcons = styled.div`
       }
     }
   }
-
-  .profile {
-    margin-left: 0.8rem;
-    cursor: pointer;
-
-    svg {
-      width: 32px;
-      height: 32px;
-    }
-  }
-
-  .toggle {
+  .my-zone {
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-left: 0.5rem;
-    transition: all 0.125s ease-in 0s;
-    cursor: pointer;
+    margin-left: 0.8rem;
 
-    svg {
-      width: 12px;
-      color: ${toggle};
+    .profile {
+      width: 32px;
+      height: 32px;
+      cursor: pointer;
     }
 
-    :hover {
-      svg {
+    .toggle {
+      margin-left: 0.5rem;
+      transition: all 0.125s ease-in 0s;
+      cursor: pointer;
+
+      width: 12px;
+      color: ${toggle};
+
+      :hover {
         color: var(--toggle-hover);
       }
     }

--- a/src/layout/Header/index.jsx
+++ b/src/layout/Header/index.jsx
@@ -14,6 +14,7 @@ import axios from 'axios';
 
 const Header = () => {
   const toggleMenuRef = useRef();
+  const myZoneRef = useRef();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
   const [toggleMenuList, setToggleMenuList] = useState([]);
   const isDarkMode = useSelector(state => state.darkMode.isDarkMode);
@@ -24,17 +25,17 @@ const Header = () => {
     isDarkMode ? dispatch(lightMode()) : dispatch(darkMode());
   };
 
-  // useEffect(() => {
-  //   const closeToggleMenu = e => {
-  //     if (isToggleOpen && toggleMenuRef !== e.target) {
-  //       setIsToggleOpen(false);
-  //     }
-  //   };
-  //   document.addEventListener('mousedown', closeToggleMenu);
-  //   return () => {
-  //     document.removeEventListener('mousedown', closeToggleMenu);
-  //   };
-  // }, [isToggleOpen]);
+  useEffect(() => {
+    const closeToggleMenu = e => {
+      if (isToggleOpen && !toggleMenuRef.current.contains(e.target) && !myZoneRef.current.contains(e.target)) {
+        setIsToggleOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', closeToggleMenu);
+    return () => {
+      document.removeEventListener('mousedown', closeToggleMenu);
+    };
+  }, [isToggleOpen]);
 
   useEffect(() => {
     (async () => {
@@ -65,7 +66,7 @@ const Header = () => {
               <Link to='/write'>새 글 작성</Link>
             </div>
           </MediaQuery>
-          <div className='my-zone' onClick={() => setIsToggleOpen(!isToggleOpen)}>
+          <div className='my-zone' ref={myZoneRef} onClick={() => setIsToggleOpen(!isToggleOpen)}>
             <CgProfile className='profile' />
             <VscTriangleDown className='toggle' />
           </div>
@@ -75,7 +76,7 @@ const Header = () => {
         <ToggleMenu ref={toggleMenuRef}>
           {toggleMenuList.map(menu => {
             return (
-              <Link key={menu.name} className='link-tag' to={menu.path}>
+              <Link key={menu.name} className='link-tag' to={menu.path} onClick={() => setIsToggleOpen(false)}>
                 {menu.name}
               </Link>
             );

--- a/src/pages/Search/index.jsx
+++ b/src/pages/Search/index.jsx
@@ -62,7 +62,7 @@ const SearchInput = styled.input`
   line-height: 2rem;
   font-size: 1.5rem;
   border: none;
-  color: ${darkModeFontColor};
+  color: var(--text);
   background-color: transparent;
   cursor: text;
 

--- a/src/pages/Search/index.jsx
+++ b/src/pages/Search/index.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { darkModeFontColor } from '../../styles/color';
 import { BiSearch } from 'react-icons/bi';
 
 const Search = () => {

--- a/src/pages/Search/index.jsx
+++ b/src/pages/Search/index.jsx
@@ -13,8 +13,6 @@ const Search = () => {
   );
 };
 
-export default Search;
-
 const Positioner = styled.div`
   display: flex;
   justify-content: center;
@@ -72,3 +70,5 @@ const SearchInput = styled.input`
     font-size: 1.125rem;
   }
 `;
+
+export default Search;

--- a/src/styles/color.js
+++ b/src/styles/color.js
@@ -1,11 +1,3 @@
-export const darkModeBackgroundColor = '#121212';
-export const darkModeFontColor = '#ECECEC';
-export const darkModeNewPostBtnColor = '#1E1E1E';
-export const darkModeToggle = '#ececec';
-export const darkModeToggleBackgound = '#1E1E1E';
-export const darkModeATagHoverText = '#96f2d7';
-export const darkModeATagHoverBackground = '#1E1E1E';
-
 export const lightModeBackgroundColor = '#FFFFFF';
 export const lightModeFontColor = '#212529';
 export const lightModeNewPostBtnColor = '#F8F9FA';
@@ -16,7 +8,6 @@ export const lightModeATagHoverText = '#12B886';
 export const lightModeATagHoverBackground = 'rgba(249, 249, 249, 0.85)';
 
 export const toggle = '#868E96';
-export const darkModeTextColor = 'D9D9D9';
 
 //dark mode
 export const backgroundPage = '#121212';

--- a/src/styles/media.js
+++ b/src/styles/media.js
@@ -1,13 +1,16 @@
-// postlist 반응형
-export const postListMaxWidth1920px = `@media screen and (max-width: 1920px) {
+// postlist & 헤더 반응형
+export const maxWidth1920px = `@media screen and (max-width: 1920px) {
   width: 1376px;
 }`;
-export const postListMaxWidth1440px = `@media screen and (max-width: 1440px) {
+export const maxWidth1440px = `@media screen and (max-width: 1440px) {
   width: 1024px;
 }`;
-export const postListMaxWidth1056px = `@media screen and (max-width: 1056px) {
+export const maxWidth1056px = `@media screen and (max-width: 1056px) {
   width: calc(100% - 2rem);
   margin: 0 auto;
+}`;
+export const minWidth250px = `@media screen and (max-width: 250px) {
+  width: 250px;
 }`;
 
 // post 반응형


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] UI 추가
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정

<br />

## :: 구현 사항 설명

1. 헤더 새 글 작성 버튼 반응형 UI 라이브러리 없이 구현
- 헤더의 "새 글 작성" 버튼의 경우는 디스플레이 너비 1024px 이하에서는 보이지 않고 토글메뉴에 나타남
- 기존에는 react-responsive 라이브러리의 Media Query 를 활용하여 반응형 구현
- 라이브러리 없이 특정 너비 이하에서`display: none;` 값을 부여하여 반응형 구현
- map을 활용한 토글메뉴의 경우는 `:nth-child()` 을 활용하여 특정 메뉴만 반응형 구현

<br />
<br />

2. media.js 활용해서 헤더/포스트리스트 반응형 전역변수로 관리
- 헤더와 메인페이지의 포스트 리스트 부분은 반응형 조건이 같으므로 src/styles/media.js 에서 전역 변수로 반응형 관리

<br />
<br />

3. 헤더 토글 메뉴 바깥영역 클릭시 닫히는 기능 추가
- 토글의 렌더링 유무를 react 라이브러리의 useState 훅을 활용하여 구현
- 닫힘 버튼이 따로 없는 토글 메뉴 같은 경우는 토글메뉴 요소를 제외한 나머지 부분을 클릭시 닫히도록 구현

<br />
<br />

4. 헤더 토글 메뉴 데이터화
- css 스타일링이 동일한 토글 메뉴의 요소들은 map을 활용하여 렌더링하기 위해 public/data/header/toggle.json 에서 메뉴이름, 클릭시 이동할 path 이름을 담은 데이터 정리
- react 라이브러리의 useEffect 와 useState 훅을 활용하여 상태값 관리

5. 토글 메뉴의 a 태그에 각각의 경로 지정
- 이전에 임시로 지정했던 path 경로를 팀원들과 상의 후 기존페이지와 동일하게 경로 지정

<br />
<br />

6. 헤더 토글 메뉴 오픈 요소 하나로 합치기
- 사용자의 프로필을 클릭하거나 토글메뉴의 화살표 아이콘을 클릭시 토글 메뉴 리스트가 렌더링 되기 때문에
- 사용자의 프로필 아이콘과 토글 메뉴의 아이콘을 하나의 div 태그에 담아서 div 태그의 onClick 이벤트에서 isToggle 상태값을 관리

<br />
<br />

7. 컴포넌트 분리
- 컴포넌트 파일의 최상위 요소를 제외하고 필요없는 styled component 정리 후 className으로 css 관리

<br />
<br />

8. 검색 페이지 검색창 글씨색 변수화
- 화이트 모드에서 검색창에 하얀글씨로 뜨는 요류 수정

<br />
<br />

9. color.js 다크모드 색상 정리
- 팀원들과 색상 코드 병합 후 중복되는 색상들 정리

<br />

## :: 성장 포인트 & 보완할 점
src/styles/color.js 와 media.js 를 활용하여 색상코드 와 반응형 조건을 전역변수로 선언 후 활용하니 중복코드를 줄일 수 있고 가독성이 좋아졌다.
또한 토글 메뉴 같이 중복되는 요소들은 data 파일에 따로 정리하여 useEffect, useState, map 함수를 이용하여 렌더링 하니 유지보수가 더 좋아졌다.
추후 다음 기능을 추가할 것이다.

1. 로그인 토큰의 유무에 따라 로그인 / 비로그인 각각의 UI 구현
2. 사용자의 프로필 사진 데이터를 받아와서 렌더링
3. 검색 페이지 검색 기능
4. 화이트 모드 색상코드 정리


