### PR TITLE
Fix: 토글 바깥 클릭시 return 오류 해결

### DIFF
--- a/src/components/PostList/index.jsx
+++ b/src/components/PostList/index.jsx
@@ -34,8 +34,8 @@ const PostList = () => {
   };
 
   const observerOptions = {
-    threshold: 0.1,
-    rootMargin: '500px',
+    threshold: 1,
+    rootMargin: '50px',
   };
 
   useEffect(() => {
@@ -63,9 +63,9 @@ const PostList = () => {
           {postData.map((_, i) => {
             return <Post key={i} />;
           })}
+          {postData.length ? <div ref={setBottom} /> : null}
           <PostSkeleton />
         </div>
-        {postData.length ? <div ref={setBottom} /> : null}
       </div>
     </PostListContainer>
   );

--- a/src/components/PostListNavBar/More/index.jsx
+++ b/src/components/PostListNavBar/More/index.jsx
@@ -1,10 +1,10 @@
 import { useRef, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import styled from 'styled-components';
+import { closeToggle } from '../../../utils/closetoggle';
 import { FiMoreVertical } from 'react-icons/fi';
 import { tabStyle } from '../../../styles/postlistnavbar';
-import axios from 'axios';
-import { closeToggle } from '../../../utils/closetoggle';
 
 const More = () => {
   const navigate = useNavigate();
@@ -27,7 +27,16 @@ const More = () => {
   }, []);
 
   useEffect(() => {
-    closeToggle(isToggle, setIsToggle, toggleBoxRef, toggleBtnRef);
+    const clickOutside = e => {
+      if (isToggle && !toggleBoxRef.current.contains(e.target) && !toggleBtnRef.current.contains(e.target)) {
+        setIsToggle(false);
+      }
+    };
+    document.addEventListener('mousedown', clickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', clickOutside);
+    };
   }, [isToggle]);
 
   return (

--- a/src/components/PostListNavBar/PeriodFilter/index.jsx
+++ b/src/components/PostListNavBar/PeriodFilter/index.jsx
@@ -3,7 +3,6 @@ import axios from 'axios';
 import styled from 'styled-components';
 import { MdOutlineArrowDropDown } from 'react-icons/md';
 import { tabStyle } from '../../../styles/postlistnavbar';
-import { closeToggle } from '../../../utils/closetoggle';
 
 const PeriodFilter = () => {
   const [isToggle, setIsToggle] = useState(false);
@@ -26,7 +25,16 @@ const PeriodFilter = () => {
   }, []);
 
   useEffect(() => {
-    closeToggle(isToggle, setIsToggle, toggleBoxRef, toggleBtnRef);
+    const clickOutside = e => {
+      if (isToggle && !toggleBoxRef.current.contains(e.target) && !toggleBtnRef.current.contains(e.target)) {
+        setIsToggle(false);
+      }
+    };
+    document.addEventListener('mousedown', clickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', clickOutside);
+    };
   }, [isToggle]);
 
   return (

--- a/src/utils/closetoggle.js
+++ b/src/utils/closetoggle.js
@@ -6,5 +6,7 @@ export const closeToggle = (isToggle, setIsToggle, toggleBoxRef, toggleBtnRef) =
   };
   document.addEventListener('mousedown', clickOutside);
 
-  return () => document.removeEventListener('mousedown', clickOutside);
+  return () => {
+    document.removeEventListener('mousedown', clickOutside);
+  };
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] UI 추가
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정

<br />

## :: 구현 사항 설명

1. 토글 바깥 클릭시 return 오류 해결
- utils에 빼서 여러곳에서 사용하던 식이 contains를 인식하지 못해 임시로 식을 컴포넌트에 하나하나 적어놓음
- 추후에 다시 수정 필요
