### PR TITLE
Refactor: 프로필이미지 컴포넌트 재사용 할 수 있게 수정

### DIFF
--- a/src/components/UserProfileImage/index.jsx
+++ b/src/components/UserProfileImage/index.jsx
@@ -1,20 +1,16 @@
 import profile from '../../assets/profile.png';
 import styled from 'styled-components';
-import { UserProfileImageMaxWidth768px } from '../../styles/media';
 
-const UserProfileImage = () => {
-  return <UserProfileImageContainer alt='profile' src={profile} />;
+const UserProfileImage = ({ source }) => {
+  return <UserProfileImageContainer alt='profile' src={source ? source : profile} />;
 };
 
 const UserProfileImageContainer = styled.img`
   display: block;
-  width: 8rem;
-  height: 8rem;
-  margin-bottom: 1.25rem;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   object-fit: cover;
-
-  ${UserProfileImageMaxWidth768px};
 `;
 
 export default UserProfileImage;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] UI 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정

<br />

## :: 구현 사항 설명

1. 프로필 이미지 컴포넌트화

- 컴포넌트를 불러와 유저 이미지 주소를 props로 내려줘서 사용할 수 있게끔 수정.
